### PR TITLE
Clickable components to use `button` component

### DIFF
--- a/src/components/CurrentUserBadge.tsx
+++ b/src/components/CurrentUserBadge.tsx
@@ -15,7 +15,7 @@ export const CurrentUserBadge: React.FC<{ onClick?: () => void; className?: stri
     <button
       type="button"
       onClick={onClick}
-      tw="inline-flex items-center bg-[#191B1F] py-2 px-3 rounded-2xl h-7 cursor-pointer"
+      tw="flex items-center bg-[#191B1F] py-2 px-3 rounded-2xl h-7 cursor-pointer"
       className={className}
     >
       <span

--- a/src/components/CurrentUserBadge.tsx
+++ b/src/components/CurrentUserBadge.tsx
@@ -1,43 +1,32 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import 'twin.macro';
 
 import { shortenAddress } from '../misc/utils';
-import { WRAPPED_SOL_MINT } from '../misc/constants';
-import { useAccounts } from '../contexts/accounts';
 
 export const CurrentUserBadge: React.FC<{ onClick?: () => void; className?: string }> = ({ onClick, className }) => {
   const { wallet, publicKey } = useWallet();
-  const { accounts } = useAccounts();
-
-  const solBalance = useMemo(() => {
-    if (accounts[WRAPPED_SOL_MINT.toString()]) {
-      return accounts[WRAPPED_SOL_MINT.toString()].balance;
-    }
-    return 0;
-  }, [publicKey, accounts]);
 
   if (!wallet || !publicKey) {
     return null;
   }
 
   return (
-    <div
+    <button
+      type="button"
       onClick={onClick}
-      tw="flex items-center bg-[#191B1F] py-2 px-3 rounded-2xl h-7 cursor-pointer"
+      tw="inline-flex items-center bg-[#191B1F] py-2 px-3 rounded-2xl h-7 cursor-pointer"
       className={className}
     >
-      <div
+      <span
         tw="w-4 h-4 rounded-full bg-[#191B1F] dark:bg-white/10 flex justify-center items-center"
         style={{ position: 'relative' }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img alt="Wallet logo" width={16} height={16} src={wallet?.adapter?.icon} />
-      </div>
+      </span>
 
-      <div tw="ml-2">
-        <div tw="text-xs text-white">{shortenAddress(`${publicKey}`)}</div>
-      </div>
-    </div>
+      <span tw="ml-2 text-xs text-white">{shortenAddress(`${publicKey}`)}</span>
+    </button>
   );
 };

--- a/src/components/UnifiedWalletButton/index.tsx
+++ b/src/components/UnifiedWalletButton/index.tsx
@@ -65,7 +65,8 @@ export const UnifiedWalletButton: React.FC<{
   return (
     <>
       {!wallet?.adapter.connected ? (
-        <div
+        <button
+          type="button"
           css={[
             overrideContent ? undefined : tw`rounded-lg text-xs py-3 px-5 font-semibold cursor-pointer text-center w-auto`,
             styles.container[theme],
@@ -74,7 +75,7 @@ export const UnifiedWalletButton: React.FC<{
           onClick={handleClick}
         >
           {overrideContent || content}
-        </div>
+        </button>
       ) : (
         <CurrentUserBadge onClick={disconnect} className={currentUserClassName} />
       )}

--- a/src/components/UnifiedWalletModal/WalletListItem.tsx
+++ b/src/components/UnifiedWalletModal/WalletListItem.tsx
@@ -30,7 +30,7 @@ export const WalletIcon: FC<WalletIconProps> = ({ wallet, width = 24, height = 2
 
   if (wallet && wallet.icon && !hasError) {
     return (
-      <div style={{ minWidth: width, minHeight: height }}>
+      <span style={{ minWidth: width, minHeight: height }}>
         {/* // eslint-disable-next-line @next/next/no-img-element */}
         <img
           width={width}
@@ -40,13 +40,13 @@ export const WalletIcon: FC<WalletIconProps> = ({ wallet, width = 24, height = 2
           tw="object-contain"
           onError={onError}
         />
-      </div>
+      </span>
     );
   } else {
     return (
-      <div style={{ minWidth: width, minHeight: height }}>
+      <span style={{ minWidth: width, minHeight: height }}>
         <UnknownIconSVG width={width} height={height} />
-      </div>
+      </span>
     );
   }
 };
@@ -67,19 +67,22 @@ export const WalletListItem = ({ handleClick, wallet }: WalletListItemProps) => 
   }, [wallet?.name]);
 
   return (
-    <li
-      onClick={handleClick}
-      css={[
-        tw`flex items-center px-5 py-4 space-x-5 cursor-pointer border border-white/10 rounded-lg hover:bg-white/10 hover:backdrop-blur-xl hover:shadow-2xl transition-all`,
-        styles.container[theme],
-      ]}
-    >
-      {isMobile() ? (
-        <WalletIcon wallet={wallet} width={24} height={24} />
-      ) : (
-        <WalletIcon wallet={wallet} width={30} height={30} />
-      )}
-      <span tw="font-semibold text-xs overflow-hidden text-ellipsis">{adapterName}</span>
+    <li>
+      <button
+        type="button"
+        onClick={handleClick}
+        css={[
+          tw`flex items-center w-full px-5 py-4 space-x-5 transition-all border rounded-lg cursor-pointer border-white/10 hover:bg-white/10 hover:backdrop-blur-xl hover:shadow-2xl`,
+          styles.container[theme],
+        ]}
+      >
+        {isMobile() ? (
+          <WalletIcon wallet={wallet} width={24} height={24} />
+        ) : (
+          <WalletIcon wallet={wallet} width={30} height={30} />
+        )}
+        <span tw="font-semibold text-xs overflow-hidden text-ellipsis">{adapterName}</span>
+      </button>
     </li>
   );
 };

--- a/src/components/UnifiedWalletModal/index.tsx
+++ b/src/components/UnifiedWalletModal/index.tsx
@@ -159,7 +159,8 @@ const ListOfWallets: React.FC<{
             const attachment = walletAttachments ? walletAttachments[adapter.name]?.attachment : null;
 
             return (
-              <div
+              <button
+                type="button"
                 key={idx}
                 onClick={(event) => onClickWallet(event, adapter)}
                 css={[
@@ -175,7 +176,7 @@ const ListOfWallets: React.FC<{
                 )}
                 <span tw="font-semibold text-xs ml-4 lg:ml-0 lg:mt-3">{adapterName}</span>
                 {attachment ? <div>{attachment}</div> : null}
-              </div>
+              </button>
             );
           })}
         </div>
@@ -190,15 +191,13 @@ const ListOfWallets: React.FC<{
 
         {list.others.length > 0 ? (
           <>
-            <div tw="mt-5 flex justify-between cursor-pointer" onClick={onToggle}>
+            <button type="button" tw="mt-5 flex w-full items-center justify-between cursor-pointer" onClick={onToggle}>
               <span tw="text-xs font-semibold">
                 <span>{t(`More wallets`)}</span>
               </span>
 
-              <div tw=" flex items-center">
-                <span tw="w-[10px] h-[6px]">{isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</span>
-              </div>
-            </div>
+              <span tw="w-[10px] h-[6px]">{isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}</span>
+            </button>
 
             <Collapse height={0} maxHeight={'auto'} expanded={isOpen}>
               {renderWalletList}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,7 +42,8 @@ const Index = () => {
 
                   <div tw="flex flex-wrap gap-3">
                     {(['light', 'dark', 'jupiter'] as IUnifiedTheme[]).map((t) => (
-                      <div
+                      <button
+                        type="button"
                         key={t}
                         onClick={() => setTheme(t)}
                         css={[
@@ -51,7 +52,7 @@ const Index = () => {
                         ]}
                       >
                         {t}
-                      </div>
+                      </button>
                     ))}
                   </div>
                 </div>
@@ -61,7 +62,8 @@ const Index = () => {
 
                   <div tw="flex flex-wrap gap-3">
                     {[DEFAULT_LANGUAGE, ...OTHER_LANGUAGES].map((l) => (
-                      <div
+                      <button
+                        type="button"
                         key={l}
                         onClick={() => setLang(l)}
                         css={[
@@ -70,7 +72,7 @@ const Index = () => {
                         ]}
                       >
                         {LANGUAGE_LABELS[l]}
-                      </div>
+                      </button>
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
### Problem

Many of the included components that are meant to be clickable (and have an `onClick` handler) use a `div` component. Since they are using a `div`, browsers will not provide the normal/expected functionality on the intractable components (like the correct cursor or allowing them to be focused). These clickable component should be use the `button` component so browsers can handle them correctly, providing a better user experience.

### Summary of changes

- updated each instance of a `div` that was acting as a button to be a real `button` component (with `type=button` to not trigger any form `onSubmit` handlers in user applications)
- the `WalletListItem` button is now wrapped in the `li` with the button having a `w-full` to ensue the same UI
- simplified the wallet modal's button used to toggle the list of "other wallets" and added the `w-full items-center` to keep the same UI for the chevron toggle
- since a `button`s child components should not be certain components like a `div` (because react may throw an error), I changed a few instances of `div`s being child components of `button` to now be `span` components (since this is safe in react). Including: the `WalletIcon` components

While I was already refactoring the `CurrentUserBadge` component, I also removed the `solBalance` variable's dead code since it was not actually in use. Making this component just a little bit smaller :)

Fixes: #11 