### PR TITLE
refactor: remove open wallet context

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,11 @@
-import { nodeExternals } from 'rollup-plugin-node-externals';
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import { nodeExternals } from 'rollup-plugin-node-externals';
 import pkg from './package.json' assert { type: 'json' };
 
 const config = {
-  name: 'OpenWallet',
+  name: 'UnifiedWallet',
   extensions: ['.ts', '.tsx', '.js', '.jsx'],
 };
 
@@ -40,7 +40,7 @@ export default {
     commonjs(),
     babel({
       extensions: config.extensions,
-      include: ['src/**/*',],
+      include: ['src/**/*'],
       exclude: 'node_modules/**',
     }),
   ],

--- a/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
+++ b/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
@@ -4,21 +4,27 @@ import React, { useContext, useEffect } from 'react';
 const OLD_KEY_NAME = 'open-wallet-previously-connected';
 const NEW_KEY_NAME = 'unified-wallet-previously-connected';
 
+const migrateLocalStorageKey = () => {
+  // Check if data exists under the old key
+  const existingData = localStorage.getItem(OLD_KEY_NAME);
+  if (existingData) {
+    // Move data to the new key
+    localStorage.setItem(NEW_KEY_NAME, existingData);
+    // Clean Up - Remove data under the old key
+    localStorage.removeItem(OLD_KEY_NAME);
+  }
+};
+
 const PreviouslyConnectedContext = React.createContext<string[]>([]);
 
 const PreviouslyConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { wallet, connected } = useWallet();
 
-  const [oldPreviouslyConnected, setOldPreviouslyConnected] = useLocalStorage<string[]>(OLD_KEY_NAME, []);
   const [previouslyConnected, setPreviouslyConnected] = useLocalStorage<string[]>(NEW_KEY_NAME, []);
 
   // TODO: Remove this block after a few releases (changes made in v0.2.0)
   useEffect(() => {
-    if (oldPreviouslyConnected) {
-      setPreviouslyConnected(oldPreviouslyConnected);
-      //@ts-ignore
-      setOldPreviouslyConnected(null);
-    }
+    migrateLocalStorageKey();
   }, []);
 
   useEffect(() => {

--- a/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
+++ b/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
@@ -1,31 +1,15 @@
 import { useLocalStorage, useWallet } from '@solana/wallet-adapter-react';
 import React, { useContext, useEffect } from 'react';
 
-const OLD_KEY_NAME = 'open-wallet-previously-connected';
-const NEW_KEY_NAME = 'unified-wallet-previously-connected';
-
-const migrateLocalStorageKey = () => {
-  // Check if data exists under the old key
-  const existingData = localStorage.getItem(OLD_KEY_NAME);
-  if (existingData) {
-    // Move data to the new key
-    localStorage.setItem(NEW_KEY_NAME, existingData);
-    // Clean Up - Remove data under the old key
-    localStorage.removeItem(OLD_KEY_NAME);
-  }
-};
-
 const PreviouslyConnectedContext = React.createContext<string[]>([]);
 
 const PreviouslyConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { wallet, connected } = useWallet();
 
-  const [previouslyConnected, setPreviouslyConnected] = useLocalStorage<string[]>(NEW_KEY_NAME, []);
-
-  // TODO: Remove this block after a few releases (changes made in v0.2.0)
-  useEffect(() => {
-    migrateLocalStorageKey();
-  }, []);
+  const [previouslyConnected, setPreviouslyConnected] = useLocalStorage<string[]>(
+    'unified-wallet-previously-connected',
+    [],
+  );
 
   useEffect(() => {
     if (connected && wallet) {

--- a/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
+++ b/src/contexts/WalletConnectionProvider/previouslyConnectedProvider.tsx
@@ -1,11 +1,25 @@
 import { useLocalStorage, useWallet } from '@solana/wallet-adapter-react';
 import React, { useContext, useEffect } from 'react';
 
+const OLD_KEY_NAME = 'open-wallet-previously-connected';
+const NEW_KEY_NAME = 'unified-wallet-previously-connected';
+
 const PreviouslyConnectedContext = React.createContext<string[]>([]);
 
 const PreviouslyConnectedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { wallet, connected } = useWallet();
-  const [previouslyConnected, setPreviouslyConnected] = useLocalStorage<string[]>(`open-wallet-previously-connected`, []);
+
+  const [oldPreviouslyConnected, setOldPreviouslyConnected] = useLocalStorage<string[]>(OLD_KEY_NAME, []);
+  const [previouslyConnected, setPreviouslyConnected] = useLocalStorage<string[]>(NEW_KEY_NAME, []);
+
+  // TODO: Remove this block after a few releases (changes made in v0.2.0)
+  useEffect(() => {
+    if (oldPreviouslyConnected) {
+      setPreviouslyConnected(oldPreviouslyConnected);
+      //@ts-ignore
+      setOldPreviouslyConnected(null);
+    }
+  }, []);
 
   useEffect(() => {
     if (connected && wallet) {


### PR DESCRIPTION
https://linear.app/raccoons/issue/RACX-1070/rename-open-wallet-package-to-unified

Rename open wallet related naming to unified wallet.